### PR TITLE
fixed time zone issue with summer time

### DIFF
--- a/app/src/main/java/be/digitalia/fosdem/utils/DateUtils.java
+++ b/app/src/main/java/be/digitalia/fosdem/utils/DateUtils.java
@@ -7,7 +7,7 @@ import java.util.TimeZone;
 
 public class DateUtils {
 
-	private static final TimeZone BELGIUM_TIME_ZONE = TimeZone.getTimeZone("GMT+1");
+	private static final TimeZone BELGIUM_TIME_ZONE = TimeZone.getTimeZone("Europe/Brussels");
 
 	private static final DateFormat TIME_DATE_FORMAT = withBelgiumTimeZone(SimpleDateFormat.getTimeInstance(SimpleDateFormat.SHORT, Locale.getDefault()));
 


### PR DESCRIPTION
this change removes issues with times. Exports to the calendar would be one hour late during CEST. 

It's likely not to affect FOSDEM, but does affect events that are using the code base in a time zone with summer time during summer time, like [Grazer Linuxtage](https://github.com/linuxtage). 

there are no issues when the events are held during winter time, but during summer time (GMT+2) it becomes a problem. Setting the timezone to "Europe/Brussels" fixes this, as it auto adjusts summer and winter time.