### PR TITLE
Update target SDK version to 30 and rewrite Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
-language: android
+language: java
 
-jdk: oraclejdk8
+os: linux
+dist: focal
+jdk: openjdk11
+
+env:
+  - ANDROID_SDK_ROOT=$HOME/android-sdk COMMAND_LINE_TOOLS_ARCHIVE=commandlinetools-linux-6858069_latest.zip
+
+install:
+  # Download latest Android command line tools if not already in cache and replace the previous ones, if any
+  - if test ! -e $ANDROID_SDK_ROOT/$COMMAND_LINE_TOOLS_ARCHIVE ; then rm -rf $ANDROID_SDK_ROOT && mkdir -p $ANDROID_SDK_ROOT && curl https://dl.google.com/android/repository/$COMMAND_LINE_TOOLS_ARCHIVE -o $ANDROID_SDK_ROOT/$COMMAND_LINE_TOOLS_ARCHIVE && unzip -qq -n $ANDROID_SDK_ROOT/$COMMAND_LINE_TOOLS_ARCHIVE -d $ANDROID_SDK_ROOT ; fi
+  # Install or update Android SDK components (no-op if already up-to-date and cached)
+  - echo y | $ANDROID_SDK_ROOT/cmdline-tools/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT 'platforms;android-30' 'build-tools;30.0.3' > /dev/null
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -8,13 +19,9 @@ before_cache:
 
 cache:
   directories:
+    - $ANDROID_SDK_ROOT
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-
-android:
-  components:
-    - android-29
-    - build-tools-29.0.3
 
 script:
   - ./gradlew clean assembleRelease

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/cbeyls/fosdem-companion-android.svg?branch=master)](https://travis-ci.org/cbeyls/fosdem-companion-android)
+[![Build Status](https://travis-ci.com/cbeyls/fosdem-companion-android.svg?branch=master)](https://travis-ci.org/cbeyls/fosdem-companion-android)
 
 # FOSDEM Companion
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,13 +4,13 @@ apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "be.digitalia.fosdem"
         minSdkVersion 17
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1700201
         versionName "2.0.1"
         // Supported languages


### PR DESCRIPTION
- update `compileSdkVersion`, `buildToolsVersion` and `targetSdkVersion` to **30**
- update Travis CI config file to use OpenJDK 11 on Ubuntu Focal and manual Android SDK components installation.