### PR TITLE
Ignore duplicated person in event

### DIFF
--- a/app/src/main/java/be/digitalia/fosdem/db/ScheduleDao.kt
+++ b/app/src/main/java/be/digitalia/fosdem/db/ScheduleDao.kt
@@ -170,7 +170,7 @@ abstract class ScheduleDao(private val appDatabase: AppDatabase) {
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     protected abstract fun insertPersons(persons: List<Person>)
 
-    @Insert
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     protected abstract fun insertEventsToPersons(eventsToPersons: Array<EventToPerson>)
 
     @Insert


### PR DESCRIPTION
Schedule can include events with duplicated persons, in that case the app fails to update the schedule.
Ignore duplicated persons so events can be updated.

Fixes #63 