### PR TITLE
Import bookmarks feature

### DIFF
--- a/app/src/main/java/be/digitalia/fosdem/activities/ExternalBookmarksActivity.kt
+++ b/app/src/main/java/be/digitalia/fosdem/activities/ExternalBookmarksActivity.kt
@@ -18,9 +18,11 @@ class ExternalBookmarksActivity : SimpleToolbarActivity() {
 
         if (savedInstanceState == null) {
             val intent = intent
-            val bookmarkIds = if (intent.hasNfcAppData()) {
-                intent.extractNfcAppData().toBookmarks()
-            } else null
+            val bookmarkIds = when {
+                intent.hasExtra(EXTRA_BOOKMARK_IDS) -> intent.getLongArrayExtra(EXTRA_BOOKMARK_IDS)
+                intent.hasNfcAppData() -> intent.extractNfcAppData().toBookmarks()
+                else -> null
+            }
             if (bookmarkIds == null) {
                 // Invalid data format, exit
                 finish()
@@ -32,5 +34,9 @@ class ExternalBookmarksActivity : SimpleToolbarActivity() {
                         args = ExternalBookmarksListFragment.createArguments(bookmarkIds))
             }
         }
+    }
+
+    companion object {
+        const val EXTRA_BOOKMARK_IDS = "bookmark_ids"
     }
 }

--- a/app/src/main/java/be/digitalia/fosdem/alarms/FosdemAlarmManager.kt
+++ b/app/src/main/java/be/digitalia/fosdem/alarms/FosdemAlarmManager.kt
@@ -1,11 +1,12 @@
 package be.digitalia.fosdem.alarms
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import androidx.annotation.MainThread
 import androidx.preference.PreferenceManager
-import be.digitalia.fosdem.model.Event
+import be.digitalia.fosdem.model.AlarmInfo
 import be.digitalia.fosdem.services.AlarmIntentService
 import be.digitalia.fosdem.utils.PreferenceKeys
 
@@ -14,6 +15,7 @@ import be.digitalia.fosdem.utils.PreferenceKeys
  *
  * @author Christophe Beyls
  */
+@SuppressLint("StaticFieldLeak")
 object FosdemAlarmManager {
 
     private lateinit var context: Context
@@ -51,20 +53,17 @@ object FosdemAlarmManager {
     }
 
     @MainThread
-    fun onBookmarkAdded(event: Event) {
+    fun onBookmarksAdded(alarmInfos: List<AlarmInfo>) {
         if (isEnabled) {
-            val serviceIntent = Intent(AlarmIntentService.ACTION_ADD_BOOKMARK).apply {
-                putExtra(AlarmIntentService.EXTRA_EVENT_ID, event.id)
-                event.startTime?.let {
-                    putExtra(AlarmIntentService.EXTRA_EVENT_START_TIME, it.time)
-                }
-            }
+            val arrayList = if (alarmInfos is ArrayList<AlarmInfo>) alarmInfos else ArrayList(alarmInfos)
+            val serviceIntent = Intent(AlarmIntentService.ACTION_ADD_BOOKMARKS)
+                    .putParcelableArrayListExtra(AlarmIntentService.EXTRA_ALARM_INFOS, arrayList)
             AlarmIntentService.enqueueWork(context, serviceIntent)
         }
     }
 
     @MainThread
-    fun onBookmarksRemoved(eventIds: LongArray?) {
+    fun onBookmarksRemoved(eventIds: LongArray) {
         if (isEnabled) {
             val serviceIntent = Intent(AlarmIntentService.ACTION_REMOVE_BOOKMARKS)
                     .putExtra(AlarmIntentService.EXTRA_EVENT_IDS, eventIds)

--- a/app/src/main/java/be/digitalia/fosdem/fragments/ExternalBookmarksListFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/ExternalBookmarksListFragment.kt
@@ -1,7 +1,12 @@
 package be.digitalia.fosdem.fragments
 
+import android.app.Dialog
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -9,10 +14,17 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import be.digitalia.fosdem.R
 import be.digitalia.fosdem.adapters.EventsAdapter
 import be.digitalia.fosdem.viewmodels.ExternalBookmarksViewModel
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 class ExternalBookmarksListFragment : Fragment(R.layout.recyclerview) {
 
     private val viewModel: ExternalBookmarksViewModel by viewModels()
+    private var addAllMenuItem: MenuItem? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -34,9 +46,49 @@ class ExternalBookmarksListFragment : Fragment(R.layout.recyclerview) {
             setBookmarkIds(bookmarkIds)
             bookmarks.observe(viewLifecycleOwner) { bookmarks ->
                 adapter.submitList(bookmarks)
+                addAllMenuItem?.isEnabled = bookmarks.isNotEmpty()
                 holder.isProgressBarVisible = false
             }
         }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.external_bookmarks, menu)
+        menu.findItem(R.id.add_all)?.let { item ->
+            val bookmarks = viewModel.bookmarks.value
+            item.isEnabled = bookmarks != null && bookmarks.isNotEmpty()
+            addAllMenuItem = item
+        }
+    }
+
+    override fun onDestroyOptionsMenu() {
+        super.onDestroyOptionsMenu()
+        addAllMenuItem = null
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        R.id.add_all -> {
+            val dialogFragment = ConfirmAddAllDialogFragment()
+            dialogFragment.setTargetFragment(this, 0)
+            dialogFragment.show(parentFragmentManager, "confirmAddAll")
+            true
+        }
+        else -> false
+    }
+
+    class ConfirmAddAllDialogFragment : DialogFragment() {
+        override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+            return MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(R.string.external_bookmarks_add_all_confirmation_title)
+                    .setMessage(R.string.external_bookmarks_add_all_confirmation_text)
+                    .setPositiveButton(android.R.string.ok) { _, _ -> (targetFragment as ExternalBookmarksListFragment).onConfirmAddAll() }
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .create()
+        }
+    }
+
+    fun onConfirmAddAll() {
+        viewModel.addAll()
     }
 
     companion object {

--- a/app/src/main/java/be/digitalia/fosdem/ical/ICalendarReader.kt
+++ b/app/src/main/java/be/digitalia/fosdem/ical/ICalendarReader.kt
@@ -46,7 +46,7 @@ class ICalendarReader(private val source: BufferedSource) : Closeable {
         state = STATE_BEGIN_VALUE
     }
 
-    fun optKey(options: Options): Int {
+    fun selectKey(options: Options): Int {
         check(state == STATE_BEGIN_KEY)
         val result = source.select(options.suffixedKey)
         if (result >= 0) {

--- a/app/src/main/java/be/digitalia/fosdem/ical/ICalendarReader.kt
+++ b/app/src/main/java/be/digitalia/fosdem/ical/ICalendarReader.kt
@@ -1,0 +1,98 @@
+package be.digitalia.fosdem.ical
+
+import be.digitalia.fosdem.ical.internal.CRLF
+import okio.Buffer
+import okio.BufferedSource
+import java.io.Closeable
+import java.io.IOException
+
+/**
+ * Optimized streaming ICalendar reader.
+ */
+class ICalendarReader(private val source: BufferedSource) : Closeable {
+    private var state = STATE_BEGIN_KEY
+
+    class Options private constructor(internal val suffixedKey: okio.Options) {
+        companion object {
+            fun of(vararg keys: String): Options {
+                val buffer = Buffer()
+                val result = Array(keys.size) {
+                    buffer.writeUtf8(keys[it])
+                    buffer.writeByte(':'.toInt())
+                    buffer.readByteString()
+                }
+                return Options(okio.Options.of(*result))
+            }
+        }
+    }
+
+    fun hasNext(): Boolean = !source.exhausted()
+
+    fun nextKey(): String {
+        check(state == STATE_BEGIN_KEY)
+        val endPosition = source.indexOf(':'.toByte())
+        endPosition >= 0L || throw IOException("Invalid key")
+        val result = source.readUtf8(endPosition)
+        source.skip(1L)
+        state = STATE_BEGIN_VALUE
+        return result
+    }
+
+    fun skipKey() {
+        check(state == STATE_BEGIN_KEY)
+        val endPosition = source.indexOf(':'.toByte())
+        endPosition >= 0L || throw IOException("Invalid key")
+        source.skip(endPosition + 1L)
+        state = STATE_BEGIN_VALUE
+    }
+
+    fun optKey(options: Options): Int {
+        check(state == STATE_BEGIN_KEY)
+        val result = source.select(options.suffixedKey)
+        if (result >= 0) {
+            state = STATE_BEGIN_VALUE
+        }
+        return result
+    }
+
+    private inline fun BufferedSource.unfoldLines(lineLambda: BufferedSource.(endPosition: Long) -> Unit) {
+        while (true) {
+            val endPosition = indexOf(CRLF)
+            if (endPosition < 0L) {
+                // buffer now contains the rest of the file until the end
+                lineLambda(buffer.size)
+                break
+            }
+            lineLambda(endPosition)
+            skip(2L)
+            if (!request(1L) || buffer[0L] != ' '.toByte()) {
+                break
+            }
+            skip(1L)
+        }
+    }
+
+    fun nextValue(): String {
+        check(state == STATE_BEGIN_VALUE)
+        val resultBuffer = Buffer()
+        source.unfoldLines { read(resultBuffer, it) }
+        state = STATE_BEGIN_KEY
+        return resultBuffer.readUtf8()
+    }
+
+    fun skipValue() {
+        check(state == STATE_BEGIN_VALUE)
+        source.unfoldLines { skip(it) }
+        state = STATE_BEGIN_KEY
+    }
+
+    @Throws(IOException::class)
+    override fun close() {
+        source.close()
+    }
+
+    companion object {
+        private const val STATE_BEGIN_KEY = 0
+        private const val STATE_BEGIN_VALUE = 1
+    }
+}

--- a/app/src/main/java/be/digitalia/fosdem/ical/ICalendarWriter.kt
+++ b/app/src/main/java/be/digitalia/fosdem/ical/ICalendarWriter.kt
@@ -1,7 +1,7 @@
 package be.digitalia.fosdem.ical
 
+import be.digitalia.fosdem.ical.internal.CRLF
 import okio.BufferedSink
-import okio.ByteString.Companion.encodeUtf8
 import java.io.Closeable
 import java.io.IOException
 
@@ -17,7 +17,7 @@ class ICalendarWriter(private val sink: BufferedSink) : Closeable {
                 writeUtf8(key)
                 writeByte(':'.toInt())
 
-                // Escape line break sequences
+                // Fold line break sequences
                 val length = value.length
                 var start = 0
                 var end = 0
@@ -46,9 +46,4 @@ class ICalendarWriter(private val sink: BufferedSink) : Closeable {
     override fun close() {
         sink.close()
     }
-
-    companion object {
-        private val CRLF = "\r\n".encodeUtf8()
-    }
-
 }

--- a/app/src/main/java/be/digitalia/fosdem/ical/ICalendarWriter.kt
+++ b/app/src/main/java/be/digitalia/fosdem/ical/ICalendarWriter.kt
@@ -1,4 +1,4 @@
-package be.digitalia.fosdem.utils
+package be.digitalia.fosdem.ical
 
 import okio.BufferedSink
 import okio.ByteString.Companion.encodeUtf8
@@ -15,7 +15,7 @@ class ICalendarWriter(private val sink: BufferedSink) : Closeable {
         if (value != null) {
             with(sink) {
                 writeUtf8(key)
-                writeUtf8CodePoint(':'.toInt())
+                writeByte(':'.toInt())
 
                 // Escape line break sequences
                 val length = value.length
@@ -26,7 +26,7 @@ class ICalendarWriter(private val sink: BufferedSink) : Closeable {
                     if (c == '\r' || c == '\n') {
                         writeUtf8(value, start, end)
                         write(CRLF)
-                        writeUtf8CodePoint(' '.toInt())
+                        writeByte(' '.toInt())
                         do {
                             end++
                         } while (end < length && (value[end] == '\r' || value[end] == '\n'))

--- a/app/src/main/java/be/digitalia/fosdem/ical/internal/Constants.kt
+++ b/app/src/main/java/be/digitalia/fosdem/ical/internal/Constants.kt
@@ -1,0 +1,5 @@
+package be.digitalia.fosdem.ical.internal
+
+import okio.ByteString.Companion.encodeUtf8
+
+internal val CRLF = "\r\n".encodeUtf8()

--- a/app/src/main/java/be/digitalia/fosdem/model/AlarmInfo.kt
+++ b/app/src/main/java/be/digitalia/fosdem/model/AlarmInfo.kt
@@ -1,14 +1,19 @@
 package be.digitalia.fosdem.model
 
+import android.os.Parcelable
 import androidx.room.ColumnInfo
 import androidx.room.TypeConverters
 import be.digitalia.fosdem.db.converters.NullableDateTypeConverters
+import be.digitalia.fosdem.utils.DateParceler
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.WriteWith
 import java.util.Date
 
-class AlarmInfo(
+@Parcelize
+data class AlarmInfo(
         @ColumnInfo(name = "event_id")
         val eventId: Long,
         @ColumnInfo(name = "start_time")
         @field:TypeConverters(NullableDateTypeConverters::class)
-        val startTime: Date?
-)
+        val startTime: @WriteWith<DateParceler> Date?
+) : Parcelable

--- a/app/src/main/java/be/digitalia/fosdem/parsers/ExportedBookmarksParser.kt
+++ b/app/src/main/java/be/digitalia/fosdem/parsers/ExportedBookmarksParser.kt
@@ -1,0 +1,45 @@
+package be.digitalia.fosdem.parsers
+
+import be.digitalia.fosdem.ical.ICalendarReader
+import okio.BufferedSource
+
+/**
+ * Extract event ids from an exported bookmarks file and validate that events match the given application id and year.
+ */
+class ExportedBookmarksParser(private val applicationId: String, year: Int) : Parser<LongArray> {
+    private val yearString = year.toString()
+
+    override fun parse(source: BufferedSource): LongArray {
+        val reader = ICalendarReader(source)
+        val eventIdList = mutableListOf<String>()
+
+        while (reader.hasNext()) {
+            if (reader.selectKey(KEYS) == -1) {
+                reader.skipKey()
+                reader.skipValue()
+            } else {
+                val uid = reader.nextValue()
+                val parts = uid.split("@")
+                // validate UID
+                if (parts.size < 3) {
+                    throw DataException("Invalid UID format: $uid")
+                }
+                if (parts[2] != applicationId) {
+                    throw DataException("Invalid application id. Expected: $applicationId, actual: ${parts[2]}")
+                }
+                if (parts[1] != yearString) {
+                    throw DataException("Invalid conference year. Expected: $yearString, actual: ${parts[1]}")
+                }
+                eventIdList += parts[0]
+            }
+        }
+
+        return LongArray(eventIdList.size) { eventIdList[it].toLong() }
+    }
+
+    class DataException(message: String) : RuntimeException(message)
+
+    companion object {
+        private val KEYS = ICalendarReader.Options.of("UID")
+    }
+}

--- a/app/src/main/java/be/digitalia/fosdem/providers/BookmarksExportProvider.kt
+++ b/app/src/main/java/be/digitalia/fosdem/providers/BookmarksExportProvider.kt
@@ -14,9 +14,9 @@ import be.digitalia.fosdem.BuildConfig
 import be.digitalia.fosdem.R
 import be.digitalia.fosdem.api.FosdemUrls
 import be.digitalia.fosdem.db.AppDatabase
+import be.digitalia.fosdem.ical.ICalendarWriter
 import be.digitalia.fosdem.model.Event
 import be.digitalia.fosdem.utils.DateUtils
-import be.digitalia.fosdem.ical.ICalendarWriter
 import be.digitalia.fosdem.utils.stripHtml
 import be.digitalia.fosdem.utils.toSlug
 import okio.buffer
@@ -144,12 +144,12 @@ class BookmarksExportProvider : ContentProvider() {
     }
 
     companion object {
+        const val TYPE = "text/calendar"
         private val URI = Uri.Builder()
                 .scheme("content")
                 .authority("${BuildConfig.APPLICATION_ID}.bookmarks")
                 .appendPath("bookmarks.ics")
                 .build()
-        private const val TYPE = "text/calendar"
         private val COLUMNS = arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE)
 
         fun getIntent(activity: Activity?): Intent {

--- a/app/src/main/java/be/digitalia/fosdem/providers/BookmarksExportProvider.kt
+++ b/app/src/main/java/be/digitalia/fosdem/providers/BookmarksExportProvider.kt
@@ -16,7 +16,7 @@ import be.digitalia.fosdem.api.FosdemUrls
 import be.digitalia.fosdem.db.AppDatabase
 import be.digitalia.fosdem.model.Event
 import be.digitalia.fosdem.utils.DateUtils
-import be.digitalia.fosdem.utils.ICalendarWriter
+import be.digitalia.fosdem.ical.ICalendarWriter
 import be.digitalia.fosdem.utils.stripHtml
 import be.digitalia.fosdem.utils.toSlug
 import okio.buffer

--- a/app/src/main/java/be/digitalia/fosdem/viewmodels/BookmarksViewModel.kt
+++ b/app/src/main/java/be/digitalia/fosdem/viewmodels/BookmarksViewModel.kt
@@ -44,7 +44,7 @@ class BookmarksViewModel(application: Application) : AndroidViewModel(applicatio
         }
 
     fun removeBookmarks(eventIds: LongArray) {
-        appDatabase.bookmarksDao.removeBookmarksAsync(*eventIds)
+        appDatabase.bookmarksDao.removeBookmarksAsync(eventIds)
     }
 
     suspend fun readBookmarkIds(uri: Uri): LongArray {

--- a/app/src/main/java/be/digitalia/fosdem/viewmodels/BookmarksViewModel.kt
+++ b/app/src/main/java/be/digitalia/fosdem/viewmodels/BookmarksViewModel.kt
@@ -1,14 +1,21 @@
 package be.digitalia.fosdem.viewmodels
 
 import android.app.Application
+import android.net.Uri
 import android.text.format.DateUtils
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.switchMap
+import be.digitalia.fosdem.BuildConfig
 import be.digitalia.fosdem.db.AppDatabase
 import be.digitalia.fosdem.livedata.LiveDataFactory
 import be.digitalia.fosdem.model.Event
+import be.digitalia.fosdem.parsers.ExportedBookmarksParser
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okio.buffer
+import okio.source
 import java.util.concurrent.TimeUnit
 
 class BookmarksViewModel(application: Application) : AndroidViewModel(application) {
@@ -38,6 +45,15 @@ class BookmarksViewModel(application: Application) : AndroidViewModel(applicatio
 
     fun removeBookmarks(eventIds: LongArray) {
         appDatabase.bookmarksDao.removeBookmarksAsync(*eventIds)
+    }
+
+    suspend fun readBookmarkIds(uri: Uri): LongArray {
+        return withContext(Dispatchers.IO) {
+            val parser = ExportedBookmarksParser(BuildConfig.APPLICATION_ID, appDatabase.scheduleDao.getYear())
+            checkNotNull(getApplication<Application>().contentResolver.openInputStream(uri)).source().buffer().use {
+                parser.parse(it)
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/be/digitalia/fosdem/viewmodels/ExternalBookmarksViewModel.kt
+++ b/app/src/main/java/be/digitalia/fosdem/viewmodels/ExternalBookmarksViewModel.kt
@@ -25,4 +25,9 @@ class ExternalBookmarksViewModel(application: Application) : AndroidViewModel(ap
             bookmarkIdsLiveData.value = bookmarkIds
         }
     }
+
+    fun addAll() {
+        val bookmarkIds = bookmarkIdsLiveData.value ?: return
+        appDatabase.bookmarksDao.addBookmarksAsync(bookmarkIds)
+    }
 }

--- a/app/src/main/res/drawable/ic_file_download_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_file_download_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z"/>
+</vector>

--- a/app/src/main/res/menu/bookmarks.xml
+++ b/app/src/main/res/menu/bookmarks.xml
@@ -20,5 +20,11 @@
         android:title="@string/export_bookmarks"
         app:iconTint="?colorControlNormal"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/import_bookmarks"
+        android:icon="@drawable/ic_file_download_white_24dp"
+        android:title="@string/import_bookmarks"
+        app:iconTint="?colorControlNormal"
+        app:showAsAction="ifRoom" />
 
 </menu>

--- a/app/src/main/res/menu/external_bookmarks.xml
+++ b/app/src/main/res/menu/external_bookmarks.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/add_all"
+        android:title="@string/external_bookmarks_add_all"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,9 @@
 
     <!-- External bookmarks -->
     <string name="external_bookmarks_title">External bookmarks</string>
+    <string name="external_bookmarks_add_all">Add all</string>
+    <string name="external_bookmarks_add_all_confirmation_title">Confirmation</string>
+    <string name="external_bookmarks_add_all_confirmation_text">Add all events to your local bookmarks?</string>
 
     <!-- Errors -->
     <string name="event_not_found_error">Unable to load the session details.\nMake sure the database has been updated to the latest version.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="upcoming_only">Upcoming only</string>
     <string name="export_bookmarks">Export bookmarks</string>
     <string name="export_bookmarks_file_name">FOSDEM %1$d bookmarks.ics</string>
+    <string name="import_bookmarks">Import bookmarks</string>
+    <string name="import_bookmarks_error">Unable to import bookmarks from the selected file.\n\nMake sure the file was created using this application and the conference year is matching.</string>
     <string name="no_bookmark">No bookmark.</string>
     <string name="remove_bookmarks">Remove bookmarks</string>
     <string name="bookmark_conflict_content_description">%1$s\n Other bookmarks are scheduled at the same time.</string>
@@ -62,7 +64,7 @@
     <string name="no_search_result">No result.</string>
 
     <!-- External bookmarks -->
-    <string name="external_bookmarks_title">Your friend\'s bookmarks</string>
+    <string name="external_bookmarks_title">External bookmarks</string>
 
     <!-- Errors -->
     <string name="event_not_found_error">Unable to load the session details.\nMake sure the database has been updated to the latest version.</string>


### PR DESCRIPTION
Allow importing back the exported iCalendar file into the application, and showing its content in the "external bookmarks" screen which was already used for Android Beam.
Check the file format to only accept files generated by the same app for the same conference year.
Add a button to add all displayed events at once to local bookmarks. The user can still manually select/unselect individual events from the list before closing the screen.