### PR TITLE
Add support for device timezone display

### DIFF
--- a/app/src/main/java/be/digitalia/fosdem/fragments/BookmarksListFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/BookmarksListFragment.kt
@@ -26,6 +26,7 @@ import be.digitalia.fosdem.activities.ExternalBookmarksActivity
 import be.digitalia.fosdem.adapters.BookmarksAdapter
 import be.digitalia.fosdem.api.FosdemApi
 import be.digitalia.fosdem.providers.BookmarksExportProvider
+import be.digitalia.fosdem.settings.UserSettingsProvider
 import be.digitalia.fosdem.utils.CreateNfcAppDataCallback
 import be.digitalia.fosdem.utils.launchAndRepeatOnLifecycle
 import be.digitalia.fosdem.utils.toBookmarksNfcAppData
@@ -47,6 +48,8 @@ import javax.inject.Named
 @AndroidEntryPoint
 class BookmarksListFragment : Fragment(R.layout.recyclerview), CreateNfcAppDataCallback {
 
+    @Inject
+    lateinit var userSettingsProvider: UserSettingsProvider
     @Inject
     @Named("UIState")
     lateinit var preferences: SharedPreferences
@@ -158,6 +161,11 @@ class BookmarksListFragment : Fragment(R.layout.recyclerview), CreateNfcAppDataC
         }
 
         viewLifecycleOwner.launchAndRepeatOnLifecycle {
+            launch {
+                userSettingsProvider.zoneId.collect { zoneId ->
+                    adapter.zoneId = zoneId
+                }
+            }
             launch {
                 api.roomStatuses.collect { statuses ->
                     adapter.roomStatuses = statuses

--- a/app/src/main/java/be/digitalia/fosdem/fragments/ExternalBookmarksListFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/ExternalBookmarksListFragment.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import be.digitalia.fosdem.R
 import be.digitalia.fosdem.adapters.EventsAdapter
 import be.digitalia.fosdem.api.FosdemApi
+import be.digitalia.fosdem.settings.UserSettingsProvider
 import be.digitalia.fosdem.utils.assistedViewModels
 import be.digitalia.fosdem.utils.launchAndRepeatOnLifecycle
 import be.digitalia.fosdem.viewmodels.ExternalBookmarksViewModel
@@ -31,6 +32,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class ExternalBookmarksListFragment : Fragment(R.layout.recyclerview) {
 
+    @Inject
+    lateinit var userSettingsProvider: UserSettingsProvider
     @Inject
     lateinit var api: FosdemApi
     @Inject
@@ -83,6 +86,11 @@ class ExternalBookmarksListFragment : Fragment(R.layout.recyclerview) {
         }
 
         viewLifecycleOwner.launchAndRepeatOnLifecycle {
+            launch {
+                userSettingsProvider.zoneId.collect { zoneId ->
+                    adapter.zoneId = zoneId
+                }
+            }
             launch {
                 api.roomStatuses.collect { statuses ->
                     adapter.roomStatuses = statuses

--- a/app/src/main/java/be/digitalia/fosdem/fragments/LiveListFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/LiveListFragment.kt
@@ -14,6 +14,7 @@ import be.digitalia.fosdem.R
 import be.digitalia.fosdem.adapters.EventsAdapter
 import be.digitalia.fosdem.api.FosdemApi
 import be.digitalia.fosdem.model.StatusEvent
+import be.digitalia.fosdem.settings.UserSettingsProvider
 import be.digitalia.fosdem.utils.launchAndRepeatOnLifecycle
 import be.digitalia.fosdem.viewmodels.LiveViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -30,6 +31,8 @@ sealed class LiveListFragment(
     private val dataSourceProvider: (LiveViewModel) -> Flow<PagingData<StatusEvent>>
 ) : Fragment(R.layout.recyclerview) {
 
+    @Inject
+    lateinit var userSettingsProvider: UserSettingsProvider
     @Inject
     lateinit var api: FosdemApi
     private val viewModel: LiveViewModel by viewModels({ requireParentFragment() })
@@ -67,6 +70,11 @@ sealed class LiveListFragment(
         }
 
         viewLifecycleOwner.launchAndRepeatOnLifecycle {
+            launch {
+                userSettingsProvider.zoneId.collect { zoneId ->
+                    adapter.zoneId = zoneId
+                }
+            }
             launch {
                 api.roomStatuses.collect { statuses ->
                     adapter.roomStatuses = statuses

--- a/app/src/main/java/be/digitalia/fosdem/fragments/PersonInfoListFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/PersonInfoListFragment.kt
@@ -14,6 +14,7 @@ import be.digitalia.fosdem.R
 import be.digitalia.fosdem.adapters.EventsAdapter
 import be.digitalia.fosdem.api.FosdemApi
 import be.digitalia.fosdem.model.Person
+import be.digitalia.fosdem.settings.UserSettingsProvider
 import be.digitalia.fosdem.utils.assistedViewModels
 import be.digitalia.fosdem.utils.launchAndRepeatOnLifecycle
 import be.digitalia.fosdem.viewmodels.PersonInfoViewModel
@@ -26,6 +27,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class PersonInfoListFragment : Fragment(R.layout.recyclerview) {
 
+    @Inject
+    lateinit var userSettingsProvider: UserSettingsProvider
     @Inject
     lateinit var api: FosdemApi
     @Inject
@@ -61,6 +64,11 @@ class PersonInfoListFragment : Fragment(R.layout.recyclerview) {
         }
 
         viewLifecycleOwner.launchAndRepeatOnLifecycle {
+            launch {
+                userSettingsProvider.zoneId.collect { zoneId ->
+                    adapter.zoneId = zoneId
+                }
+            }
             launch {
                 api.roomStatuses.collect { statuses ->
                     adapter.roomStatuses = statuses

--- a/app/src/main/java/be/digitalia/fosdem/fragments/SearchResultListFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/SearchResultListFragment.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import be.digitalia.fosdem.R
 import be.digitalia.fosdem.adapters.EventsAdapter
 import be.digitalia.fosdem.api.FosdemApi
+import be.digitalia.fosdem.settings.UserSettingsProvider
 import be.digitalia.fosdem.utils.launchAndRepeatOnLifecycle
 import be.digitalia.fosdem.viewmodels.SearchViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,6 +23,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class SearchResultListFragment : Fragment(R.layout.recyclerview) {
 
+    @Inject
+    lateinit var userSettingsProvider: UserSettingsProvider
     @Inject
     lateinit var api: FosdemApi
     private val viewModel: SearchViewModel by activityViewModels()
@@ -46,6 +49,11 @@ class SearchResultListFragment : Fragment(R.layout.recyclerview) {
         }
 
         viewLifecycleOwner.launchAndRepeatOnLifecycle {
+            launch {
+                userSettingsProvider.zoneId.collect { zoneId ->
+                    adapter.zoneId = zoneId
+                }
+            }
             launch {
                 api.roomStatuses.collect { statuses ->
                     adapter.roomStatuses = statuses

--- a/app/src/main/java/be/digitalia/fosdem/settings/PreferenceKeys.kt
+++ b/app/src/main/java/be/digitalia/fosdem/settings/PreferenceKeys.kt
@@ -1,6 +1,7 @@
 package be.digitalia.fosdem.settings
 
 object PreferenceKeys {
+    const val USE_DEVICE_TIME_ZONE = "use_device_time_zone"
     const val THEME = "theme"
     const val NOTIFICATIONS_ENABLED = "notifications_enabled"
     // Android >= O only

--- a/app/src/main/java/be/digitalia/fosdem/settings/SharedPreferencesExt.kt
+++ b/app/src/main/java/be/digitalia/fosdem/settings/SharedPreferencesExt.kt
@@ -1,7 +1,6 @@
 package be.digitalia.fosdem.settings
 
 import android.content.SharedPreferences
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -24,7 +23,6 @@ fun SharedPreferences.getBooleanAsFlow(key: String): Flow<Boolean> {
     }
 }
 
-@OptIn(ExperimentalCoroutinesApi::class)
 private inline fun <T> SharedPreferences.getAsFlow(
         key: String,
         crossinline valueProvider: SharedPreferences.(key: String) -> T

--- a/app/src/main/java/be/digitalia/fosdem/settings/UserSettingsProvider.kt
+++ b/app/src/main/java/be/digitalia/fosdem/settings/UserSettingsProvider.kt
@@ -60,8 +60,8 @@ class UserSettingsProvider @Inject constructor(@ApplicationContext context: Cont
 
     val notificationsDelayInMillis: Flow<Long>
         get() = sharedPreferences.getStringAsFlow(PreferenceKeys.NOTIFICATIONS_DELAY)
-                .map {
-                    // Convert from minutes to milliseconds
-                    TimeUnit.MINUTES.toMillis(it?.toLong() ?: 0L)
-                }
+            .map {
+                // Convert from minutes to milliseconds
+                TimeUnit.MINUTES.toMillis(it?.toLong() ?: 0L)
+            }
 }

--- a/app/src/main/java/be/digitalia/fosdem/settings/UserSettingsProvider.kt
+++ b/app/src/main/java/be/digitalia/fosdem/settings/UserSettingsProvider.kt
@@ -1,11 +1,22 @@
 package be.digitalia.fosdem.settings
 
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import androidx.preference.PreferenceManager
 import be.digitalia.fosdem.R
+import be.digitalia.fosdem.utils.DateUtils
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,9 +29,25 @@ class UserSettingsProvider @Inject constructor(@ApplicationContext context: Cont
         PreferenceManager.setDefaultValues(context, R.xml.settings, false)
     }
 
+    private val conferenceZoneIdFlow: Flow<ZoneId> = flowOf(DateUtils.conferenceZoneId)
+    private val deviceZoneIdFlow: StateFlow<ZoneId> by lazy(LazyThreadSafetyMode.NONE) {
+        val zoneIdFlow = MutableStateFlow(ZoneId.systemDefault())
+        context.registerReceiver(object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                zoneIdFlow.value = ZoneId.systemDefault()
+            }
+        }, IntentFilter(Intent.ACTION_TIMEZONE_CHANGED))
+        zoneIdFlow.asStateFlow()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val zoneId: Flow<ZoneId>
+        get() = sharedPreferences.getBooleanAsFlow(PreferenceKeys.USE_DEVICE_TIME_ZONE)
+            .flatMapLatest { if (it) deviceZoneIdFlow else conferenceZoneIdFlow }
+
     val theme: Flow<Int?>
         get() = sharedPreferences.getStringAsFlow(PreferenceKeys.THEME)
-                .map { it?.toInt() }
+            .map { it?.toInt() }
 
     val isNotificationsEnabled: Flow<Boolean>
         get() = sharedPreferences.getBooleanAsFlow(PreferenceKeys.NOTIFICATIONS_ENABLED)

--- a/app/src/main/java/be/digitalia/fosdem/utils/DateUtils.kt
+++ b/app/src/main/java/be/digitalia/fosdem/utils/DateUtils.kt
@@ -8,7 +8,9 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 object DateUtils {
-    val conferenceZoneId: ZoneId = ZoneOffset.ofHours(1)
+    private const val CONFERENCE_ZONE_OFFSET_HOURS = 1
+
+    val conferenceZoneId: ZoneId = ZoneOffset.ofHours(CONFERENCE_ZONE_OFFSET_HOURS)
 
     fun getTimeFormatter(context: Context): DateTimeFormatter {
         val primaryLocale = ConfigurationCompat.getLocales(context.resources.configuration)[0]

--- a/app/src/main/java/be/digitalia/fosdem/utils/DateUtils.kt
+++ b/app/src/main/java/be/digitalia/fosdem/utils/DateUtils.kt
@@ -3,8 +3,10 @@ package be.digitalia.fosdem.utils
 import android.content.Context
 import android.text.format.DateFormat
 import androidx.core.os.ConfigurationCompat
+import java.time.Instant
 import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 object DateUtils {
@@ -18,4 +20,8 @@ object DateUtils {
         val bestPattern = DateFormat.getBestDateTimePattern(primaryLocale, basePattern)
         return DateTimeFormatter.ofPattern(bestPattern, primaryLocale)
     }
+}
+
+fun Instant.atZoneOrNull(zoneId: ZoneId?): ZonedDateTime? {
+    return if (zoneId != null) atZone(zoneId) else null
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,10 @@
 
     <!-- Settings -->
     <string name="settings">Settings</string>
+    <string name="settings_general">General</string>
+    <string name="settings_general_use_device_time_zone_title">Use device time zone</string>
+    <string name="settings_general_use_device_time_zone_summary_off">Display dates and times using the conference time zone</string>
+    <string name="settings_general_use_device_time_zone_summary_on">Display dates and times using the device time zone</string>
     <string name="settings_appearance">Appearance</string>
     <string name="settings_appearance_theme_title">Theme</string>
     <string-array name="settings_appearance_theme_entries">

--- a/app/src/main/res/xml-v26/settings.xml
+++ b/app/src/main/res/xml-v26/settings.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.preference.PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <PreferenceCategory app:title="@string/settings_general">
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="use_device_time_zone"
+            app:summaryOff="@string/settings_general_use_device_time_zone_summary_off"
+            app:summaryOn="@string/settings_general_use_device_time_zone_summary_on"
+            app:title="@string/settings_general_use_device_time_zone_title" />
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="@string/settings_appearance">
         <ListPreference
             app:defaultValue="-1"

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.preference.PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <PreferenceCategory app:title="@string/settings_general">
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="use_device_time_zone"
+            app:summaryOff="@string/settings_general_use_device_time_zone_summary_off"
+            app:summaryOn="@string/settings_general_use_device_time_zone_summary_on"
+            app:title="@string/settings_general_use_device_time_zone_title" />
+    </PreferenceCategory>
+
     <PreferenceCategory app:title="@string/settings_appearance">
         <ListPreference
             app:defaultValue="-1"


### PR DESCRIPTION
The `ZoneId` used to display all dates and times is currently hardcoded to the conference timezone.

Change code to allow observing the `ZoneId` and update display on changes. The `ZoneId` is selected according to user settings, it's either the conference timezone like before or the local timezone which is monitored in real time.