### PR TITLE
refactor: Migrate to Room 2.7, improve HttpClient abstraction, add TimeSource abstraction globally

### DIFF
--- a/app/src/main/java/be/digitalia/fosdem/activities/MainActivity.kt
+++ b/app/src/main/java/be/digitalia/fosdem/activities/MainActivity.kt
@@ -321,7 +321,7 @@ class MainActivity : AppCompatActivity(R.layout.main) {
                 .setShowTitle(true)
                 .build()
                 .launchUrl(this, url.toUri())
-        } catch (ignore: ActivityNotFoundException) {
+        } catch (_: ActivityNotFoundException) {
         }
     }
 

--- a/app/src/main/java/be/digitalia/fosdem/activities/PersonInfoActivity.kt
+++ b/app/src/main/java/be/digitalia/fosdem/activities/PersonInfoActivity.kt
@@ -61,7 +61,7 @@ class PersonInfoActivity : AppCompatActivity(R.layout.person_info) {
                             .setExitAnimations(context, R.anim.slide_in_left, R.anim.slide_out_right)
                             .build()
                             .launchUrl(context, url.toUri())
-                    } catch (ignore: ActivityNotFoundException) {
+                    } catch (_: ActivityNotFoundException) {
                     }
                 }
             }

--- a/app/src/main/java/be/digitalia/fosdem/activities/RoomImageDialogActivity.kt
+++ b/app/src/main/java/be/digitalia/fosdem/activities/RoomImageDialogActivity.kt
@@ -81,7 +81,7 @@ class RoomImageDialogActivity : AppCompatActivity(R.layout.dialog_room_image) {
                                         .setShowTitle(true)
                                         .build()
                                         .launchUrl(context, localNavigationUrl.toUri())
-                            } catch (ignore: ActivityNotFoundException) {
+                            } catch (_: ActivityNotFoundException) {
                             }
                             true
                         }

--- a/app/src/main/java/be/digitalia/fosdem/api/FosdemApi.kt
+++ b/app/src/main/java/be/digitalia/fosdem/api/FosdemApi.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okio.buffer
 import javax.inject.Inject
 import javax.inject.Provider
@@ -81,7 +82,7 @@ class FosdemApi @Inject constructor(
             when (response) {
                 is HttpClient.Response.NotModified -> DownloadScheduleResult.UpToDate    // Nothing parsed, the result is up-to-date
                 is HttpClient.Response.Success -> {
-                    val result = with (Dispatchers.IO) {
+                    val result = withContext(Dispatchers.IO) {
                         val httpResponse = response.body
                         val length = httpResponse.contentLength
                         val source = if (length > 0L) {

--- a/app/src/main/java/be/digitalia/fosdem/api/FosdemApi.kt
+++ b/app/src/main/java/be/digitalia/fosdem/api/FosdemApi.kt
@@ -192,7 +192,7 @@ class FosdemApi @Inject constructor(
                     val multiplier = 2.0.pow(retryAttempt)
                     retryAttempt++
                     (ROOM_STATUS_FIRST_RETRY_DELAY * multiplier).let {
-                        // Avoid using use minOf() or coerceAtMost() which cause boxing of value class Duration
+                        // Avoid using minOf() or coerceAtMost() which cause boxing of inline class Duration
                         if (it > ROOM_STATUS_REFRESH_DELAY) ROOM_STATUS_REFRESH_DELAY else it
                     }
                 }

--- a/app/src/main/java/be/digitalia/fosdem/api/network/HttpClient.kt
+++ b/app/src/main/java/be/digitalia/fosdem/api/network/HttpClient.kt
@@ -1,0 +1,58 @@
+package be.digitalia.fosdem.api.network
+
+import okio.BufferedSource
+
+/**
+ * High-level coroutines-based HTTP client abstraction.
+ *
+ * @author Christophe Beyls
+ */
+interface HttpClient {
+
+    /**
+     * Important: it's the caller responsibility to close the response body.
+     *
+     * @param httpResponseParser A block of code to optionally transform the Http response on a background thread.
+     */
+    suspend fun <T> get(url: String, httpResponseParser: (HttpResponse) -> T): Response.Success<T> {
+        return when (val response = get(url, null, httpResponseParser)) {
+            // Can only receive NotModified if lastModified argument is non-null
+            is Response.NotModified -> throw IllegalStateException()
+            is Response.Success -> response
+        }
+    }
+
+    /**
+     * Important: it's the caller responsibility to close the response body.
+     *
+     * @param lastModified header value matching a previous "Last-Modified" response header.
+     */
+    suspend fun get(url: String, lastModified: String?): Response<HttpResponse> = get(url, lastModified) { it }
+
+    /**
+     * Important: it's the caller responsibility to close the response body.
+     *
+     * @param lastModified header value matching a previous "Last-Modified" response header.
+     * @param httpResponseParser A block of code to optionally transform the Http response on a background thread.
+     */
+    suspend fun <T> get(url: String, lastModified: String?, httpResponseParser: (HttpResponse) -> T): Response<T>
+
+    interface HttpResponse {
+        val body: BufferedSource
+
+        /**
+         * @return The content length or -1 if unknown.
+         */
+        val contentLength: Long
+
+        /**
+         * @return The value of the Last-Modified header or null if absent.
+         */
+        val lastModified: String?
+    }
+
+    sealed interface Response<out T> {
+        data object NotModified : Response<Nothing>
+        class Success<T>(val body: T) : Response<T>
+    }
+}

--- a/app/src/main/java/be/digitalia/fosdem/api/network/OkHttpClientImpl.kt
+++ b/app/src/main/java/be/digitalia/fosdem/api/network/OkHttpClientImpl.kt
@@ -1,12 +1,14 @@
-package be.digitalia.fosdem.utils.network
+package be.digitalia.fosdem.api.network
 
+import be.digitalia.fosdem.api.network.HttpClient.HttpResponse
+import be.digitalia.fosdem.api.network.HttpClient.Response
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
-import okhttp3.Headers
 import okhttp3.Request
-import okhttp3.ResponseBody
+import okhttp3.internal.closeQuietly
+import okio.BufferedSource
 import java.io.IOException
 import java.net.HttpURLConnection
 import javax.inject.Inject
@@ -14,24 +16,14 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /**
- * High-level coroutines-based HTTP client.
+ * High-level coroutines-based HTTP client implementation based on OkHttp.
  *
  * @author Christophe Beyls
  */
-class HttpClient @Inject constructor(private val deferredCallFactory: @JvmSuppressWildcards Deferred<Call.Factory>) {
-
-    suspend fun <T> get(url: String, bodyParser: (body: ResponseBody, headers: Headers) -> T): Response.Success<T> {
-        return when (val response = get(url, null, bodyParser)) {
-            // Can only receive NotModified if lastModified argument is non-null
-            is Response.NotModified -> throw IllegalStateException()
-            is Response.Success -> response
-        }
-    }
-
-    /**
-     * @param lastModified header value matching a previous "Last-Modified" response header.
-     */
-    suspend fun <T> get(url: String, lastModified: String?, bodyParser: (body: ResponseBody, headers: Headers) -> T): Response<T> {
+class OkHttpClientImpl @Inject constructor(
+    private val deferredCallFactory: @JvmSuppressWildcards Deferred<Call.Factory>
+) : HttpClient {
+    override suspend fun <T> get(url: String, lastModified: String?, httpResponseParser: (HttpResponse) -> T): Response<T> {
         val requestBuilder = Request.Builder()
         if (lastModified != null) {
             requestBuilder.header("If-Modified-Since", lastModified)
@@ -51,7 +43,7 @@ class HttpClient @Inject constructor(private val deferredCallFactory: @JvmSuppre
                     // This block is invoked on OkHttp's network thread
                     val body = response.body
                     if (!response.isSuccessful) {
-                        body?.close()
+                        body?.closeQuietly()
                         if (lastModified != null && response.code == HttpURLConnection.HTTP_NOT_MODIFIED) {
                             // Cached result is still valid; return an empty response
                             continuation.resume(Response.NotModified)
@@ -60,8 +52,17 @@ class HttpClient @Inject constructor(private val deferredCallFactory: @JvmSuppre
                         }
                     } else {
                         try {
-                            val parsedBody = checkNotNull(body).use { bodyParser(it, response.headers) }
-                            continuation.resume(Response.Success(parsedBody, response))
+                            checkNotNull(body) { "Unexpected empty response body" }
+                            val httpResponse = object : HttpResponse {
+                                override val body: BufferedSource
+                                    get() = body.source()
+                                override val contentLength: Long
+                                    get() = body.contentLength()
+                                override val lastModified: String?
+                                    get() = response.headers["Last-Modified"]
+                            }
+                            val parsedBody = httpResponseParser(httpResponse)
+                            continuation.resume(Response.Success(parsedBody))
                         } catch (e: Exception) {
                             continuation.resumeWithException(e)
                         }
@@ -70,14 +71,5 @@ class HttpClient @Inject constructor(private val deferredCallFactory: @JvmSuppre
             })
             continuation.invokeOnCancellation { call.cancel() }
         }
-    }
-
-    sealed class Response<out T> {
-        data object NotModified : Response<Nothing>()
-        class Success<T>(val body: T, val raw: okhttp3.Response) : Response<T>()
-    }
-
-    companion object {
-        const val LAST_MODIFIED_HEADER_NAME = "Last-Modified"
     }
 }

--- a/app/src/main/java/be/digitalia/fosdem/api/network/OkHttpClientImpl.kt
+++ b/app/src/main/java/be/digitalia/fosdem/api/network/OkHttpClientImpl.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Request
-import okhttp3.internal.closeQuietly
 import okio.BufferedSource
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -43,7 +42,7 @@ class OkHttpClientImpl @Inject constructor(
                     // This block is invoked on OkHttp's network thread
                     val body = response.body
                     if (!response.isSuccessful) {
-                        body?.closeQuietly()
+                        body?.close()
                         if (lastModified != null && response.code == HttpURLConnection.HTTP_NOT_MODIFIED) {
                             // Cached result is still valid; return an empty response
                             continuation.resume(Response.NotModified)

--- a/app/src/main/java/be/digitalia/fosdem/db/RoomDatabaseExt.kt
+++ b/app/src/main/java/be/digitalia/fosdem/db/RoomDatabaseExt.kt
@@ -1,7 +1,6 @@
 package be.digitalia.fosdem.db
 
 import androidx.room.RoomDatabase
-import androidx.room.invalidationTrackerFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -12,7 +11,7 @@ import kotlinx.coroutines.flow.shareIn
 fun RoomDatabase.createVersionFlow(scope: CoroutineScope, vararg tables: String): Flow<Int> {
     return flow {
         var version = 0
-        invalidationTrackerFlow(*tables).collect {
+        invalidationTracker.createFlow(*tables).collect {
             emit(version++)
         }
     }

--- a/app/src/main/java/be/digitalia/fosdem/flow/Timers.kt
+++ b/app/src/main/java/be/digitalia/fosdem/flow/Timers.kt
@@ -1,6 +1,5 @@
 package be.digitalia.fosdem.flow
 
-import be.digitalia.fosdem.utils.ElapsedRealTimeSource
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -23,7 +22,7 @@ fun tickerFlow(period: Duration): Flow<Unit> = flow {
  */
 fun SharedFlowContext.synchronizedTickerFlow(
     period: Duration,
-    timeSource: TimeSource = ElapsedRealTimeSource
+    timeSource: TimeSource
 ): Flow<Unit> {
     return flow {
         var nextEmissionTimeMark: TimeMark? = null

--- a/app/src/main/java/be/digitalia/fosdem/fragments/BookmarksListFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/BookmarksListFragment.kt
@@ -208,7 +208,7 @@ class BookmarksListFragment : Fragment(R.layout.recyclerview) {
                 }
             } catch (e: CancellationException) {
                 throw e
-            } catch (ignore: Exception) {
+            } catch (_: Exception) {
                 withStarted {
                     ImportBookmarksErrorDialogFragment().show(
                         parentFragmentManager,

--- a/app/src/main/java/be/digitalia/fosdem/fragments/EventDetailsFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/EventDetailsFragment.kt
@@ -296,7 +296,7 @@ class EventDetailsFragment : Fragment(R.layout.fragment_event_details) {
 
         try {
             startActivity(intent)
-        } catch (e: ActivityNotFoundException) {
+        } catch (_: ActivityNotFoundException) {
             Snackbar.make(requireView(), R.string.calendar_not_found, Snackbar.LENGTH_LONG).show()
         }
     }
@@ -403,7 +403,7 @@ class EventDetailsFragment : Fragment(R.layout.fragment_event_details) {
                     .setExitAnimations(context, R.anim.slide_in_left, R.anim.slide_out_right)
                     .build()
                     .launchUrl(context, url.toUri())
-            } catch (ignore: ActivityNotFoundException) {
+            } catch (_: ActivityNotFoundException) {
             }
         }
     }

--- a/app/src/main/java/be/digitalia/fosdem/fragments/MapFragment.kt
+++ b/app/src/main/java/be/digitalia/fosdem/fragments/MapFragment.kt
@@ -55,7 +55,7 @@ class MapFragment : Fragment(R.layout.fragment_map) {
 
         try {
             startActivity(intent)
-        } catch (ignore: ActivityNotFoundException) {
+        } catch (_: ActivityNotFoundException) {
         }
     }
 
@@ -67,7 +67,7 @@ class MapFragment : Fragment(R.layout.fragment_map) {
                     .setShowTitle(true)
                     .build()
                     .launchUrl(context, FosdemUrls.localNavigation.toUri())
-        } catch (ignore: ActivityNotFoundException) {
+        } catch (_: ActivityNotFoundException) {
         }
     }
 

--- a/app/src/main/java/be/digitalia/fosdem/inject/NetworkModule.kt
+++ b/app/src/main/java/be/digitalia/fosdem/inject/NetworkModule.kt
@@ -1,6 +1,8 @@
 package be.digitalia.fosdem.inject
 
 import android.os.Build
+import be.digitalia.fosdem.api.network.HttpClient
+import be.digitalia.fosdem.api.network.OkHttpClientImpl
 import be.digitalia.fosdem.utils.BackgroundWorkScope
 import dagger.Module
 import dagger.Provides
@@ -54,6 +56,9 @@ oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
 mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
 emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
 -----END CERTIFICATE-----"""
+
+    @Provides
+    fun provideHttpClient(impl: OkHttpClientImpl): HttpClient = impl
 
     @Provides
     fun provideOkHttpClient(): OkHttpClient {

--- a/app/src/main/java/be/digitalia/fosdem/inject/TimeModule.kt
+++ b/app/src/main/java/be/digitalia/fosdem/inject/TimeModule.kt
@@ -1,0 +1,15 @@
+package be.digitalia.fosdem.inject
+
+import be.digitalia.fosdem.utils.ElapsedRealTimeSource
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlin.time.TimeSource
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TimeModule {
+    @Provides
+    fun provideTimeSource(): TimeSource = ElapsedRealTimeSource
+}

--- a/app/src/main/java/be/digitalia/fosdem/parsers/RoomStatusesParser.kt
+++ b/app/src/main/java/be/digitalia/fosdem/parsers/RoomStatusesParser.kt
@@ -23,7 +23,7 @@ class RoomStatusesParser : Parser<Map<String, RoomStatus>> {
                         val stateValue = reader.nextInt()
                         try {
                             roomStatus = RoomStatus.entries[stateValue]
-                        } catch (e: Exception) {
+                        } catch (_: Exception) {
                             // Swallow and ignore that room
                         }
                     }

--- a/app/src/main/java/be/digitalia/fosdem/parsers/ScheduleParser.kt
+++ b/app/src/main/java/be/digitalia/fosdem/parsers/ScheduleParser.kt
@@ -147,7 +147,7 @@ class ScheduleParser @Inject constructor() : Parser<Schedule> {
                     "track" -> trackName = parser.nextText()
                     "type" -> try {
                         trackType = enumValueOf(parser.nextText())
-                    } catch (e: Exception) {
+                    } catch (_: Exception) {
                         // trackType will be "other"
                     }
                     "abstract" -> abstractText = parser.nextText()

--- a/app/src/main/java/be/digitalia/fosdem/providers/BookmarksExportProvider.kt
+++ b/app/src/main/java/be/digitalia/fosdem/providers/BookmarksExportProvider.kt
@@ -118,12 +118,12 @@ class BookmarksExportProvider : ContentProvider() {
                     )
                 } catch (e: CancellationException) {
                     throw e
-                } catch (ignore: Exception) {
+                } catch (_: Exception) {
                     // Swallow exception
                 }
             }
             pipe[0]
-        } catch (e: IOException) {
+        } catch (_: IOException) {
             throw FileNotFoundException("Could not open pipe")
         }
     }

--- a/app/src/main/java/be/digitalia/fosdem/settings/UserSettingsProvider.kt
+++ b/app/src/main/java/be/digitalia/fosdem/settings/UserSettingsProvider.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.SharedPreferences
 import androidx.core.content.ContextCompat
+import androidx.core.content.edit
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -15,8 +16,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import java.time.Duration
 import java.time.ZoneId
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -52,9 +53,9 @@ class UserSettingsProvider @Inject constructor(
         get() = sharedPreferences.getBooleanAsFlow(PreferenceKeys.NOTIFICATIONS_ENABLED)
 
     fun updateNotificationsEnabled(notificationsEnabled: Boolean) {
-        sharedPreferences.edit()
-            .putBoolean(PreferenceKeys.NOTIFICATIONS_ENABLED, notificationsEnabled)
-            .apply()
+        sharedPreferences.edit {
+            putBoolean(PreferenceKeys.NOTIFICATIONS_ENABLED, notificationsEnabled)
+        }
     }
 
     val isNotificationsVibrationEnabled: Flow<Boolean>
@@ -63,10 +64,9 @@ class UserSettingsProvider @Inject constructor(
     val isNotificationsLedEnabled: Flow<Boolean>
         get() = sharedPreferences.getBooleanAsFlow(PreferenceKeys.NOTIFICATIONS_LED)
 
-    val notificationsDelayInMillis: Flow<Long>
+    val notificationsDelay: Flow<Duration>
         get() = sharedPreferences.getStringAsFlow(PreferenceKeys.NOTIFICATIONS_DELAY)
-            .map {
-                // Convert from minutes to milliseconds
-                TimeUnit.MINUTES.toMillis(it?.toLong() ?: 0L)
+            .map { stringDelayInMinutes ->
+                stringDelayInMinutes?.let { Duration.ofMinutes(it.toLong()) } ?: Duration.ZERO
             }
 }

--- a/app/src/main/java/be/digitalia/fosdem/utils/ElapsedRealTimeSource.kt
+++ b/app/src/main/java/be/digitalia/fosdem/utils/ElapsedRealTimeSource.kt
@@ -4,6 +4,9 @@ import android.os.SystemClock
 import kotlin.time.AbstractLongTimeSource
 import kotlin.time.DurationUnit
 
+/**
+ * The best monotonic time source for the Android platform.
+ */
 object ElapsedRealTimeSource : AbstractLongTimeSource(DurationUnit.NANOSECONDS) {
     override fun read(): Long = SystemClock.elapsedRealtimeNanos()
     override fun toString(): String = "TimeSource(SystemClock.elapsedRealtimeNanos())"

--- a/app/src/main/java/be/digitalia/fosdem/viewmodels/BookmarksViewModel.kt
+++ b/app/src/main/java/be/digitalia/fosdem/viewmodels/BookmarksViewModel.kt
@@ -33,13 +33,15 @@ import okio.source
 import java.time.Instant
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeSource
 
 @HiltViewModel
 class BookmarksViewModel @Inject constructor(
     private val bookmarksDao: BookmarksDao,
     private val scheduleDao: ScheduleDao,
     private val alarmManager: AppAlarmManager,
-    private val application: Application
+    private val application: Application,
+    private val timeSource: TimeSource
 ) : ViewModel() {
 
     private val hidePastEventsStateFlow = MutableStateFlow<Boolean?>(null)
@@ -49,7 +51,7 @@ class BookmarksViewModel @Inject constructor(
         hidePastEventsStateFlow.filterNotNull().flatMapLatest { hidePastEvents ->
             if (hidePastEvents) {
                 // Refresh upcoming bookmarks every 2 minutes
-                synchronizedTickerFlow(REFRESH_PERIOD)
+                synchronizedTickerFlow(REFRESH_PERIOD, timeSource)
                     .flatMapLatest {
                         getObservableBookmarks(Instant.now())
                     }

--- a/app/src/main/java/be/digitalia/fosdem/viewmodels/LiveViewModel.kt
+++ b/app/src/main/java/be/digitalia/fosdem/viewmodels/LiveViewModel.kt
@@ -24,13 +24,17 @@ import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeSource
 
 @HiltViewModel
-class LiveViewModel @Inject constructor(scheduleDao: ScheduleDao) : ViewModel() {
+class LiveViewModel @Inject constructor(
+    scheduleDao: ScheduleDao,
+    timeSource: TimeSource
+) : ViewModel() {
 
     // Share a single ticker providing the time to ensure both lists are synchronized
     private val ticker: Flow<Instant> = stateFlow(viewModelScope, null) {
-        synchronizedTickerFlow(REFRESH_PERIOD)
+        synchronizedTickerFlow(REFRESH_PERIOD, timeSource)
             .map { Instant.now() }
     }.filterNotNull()
 

--- a/app/src/main/java/be/digitalia/fosdem/widgets/PhotoViewDrawerLayout.kt
+++ b/app/src/main/java/be/digitalia/fosdem/widgets/PhotoViewDrawerLayout.kt
@@ -21,7 +21,7 @@ class PhotoViewDrawerLayout : DrawerLayout {
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
         return try {
             super.onInterceptTouchEvent(ev)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             false
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,28 +1,28 @@
 [versions]
-androidGradlePlugin = "8.8.1"
-androidx-activity = "1.10.0"
+androidGradlePlugin = "8.10.1"
+androidx-activity = "1.10.1"
 androidx-appcompat = "1.7.0"
 androidx-browser = "1.8.0"
-androidx-coordinatorlayout = "1.2.0"
-androidx-core = "1.15.0"
-androidx-datastore = "1.1.2"
+androidx-coordinatorlayout = "1.3.0"
+androidx-core = "1.16.0"
+androidx-datastore = "1.1.7"
 androidx-drawerlayout = "1.2.0"
-androidx-fragment = "1.8.6"
-androidx-lifecycle = "2.8.7"
+androidx-fragment = "1.8.7"
+androidx-lifecycle = "2.9.0"
 androidx-paging = "3.3.6"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.4.0"
-androidx-room = "2.6.1"
+androidx-room = "2.7.1"
 androidx-viewpager2 = "1.1.0"
-desugarJdkLibs = "2.1.4"
-hilt = "2.55"
-kotlin = "2.1.10"
-kotlinx-coroutines = "1.10.1"
-ksp = "2.1.10-1.0.30"
+desugarJdkLibs = "2.1.5"
+hilt = "2.56.2"
+kotlin = "2.1.21"
+kotlinx-coroutines = "1.10.2"
+ksp = "2.1.21-2.0.1"
 material = "1.12.0"
 moshi = "1.15.2"
 okhttp = "4.12.0"
-okio = "3.10.2"
+okio = "3.12.0"
 photoview = "2.3.0"
 
 [plugins]
@@ -41,14 +41,14 @@ androidx-core =  { group = "androidx.core", name = "core-ktx", version.ref = "an
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidx-datastore" }
 androidx-drawerlayout =  { group = "androidx.drawerlayout", name = "drawerlayout", version.ref = "androidx-drawerlayout" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidx-fragment" }
-androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
-androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
-androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime-ktx", version.ref = "androidx-paging" }
+androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "androidx-paging" }
 androidx-preference = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidx-preference" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidx-recyclerview" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidx-room" }
 androidx-room-paging = { group = "androidx.room", name = "room-paging", version.ref = "androidx-room" }
-androidx-room-runtime = { group = "androidx.room", name = "room-ktx", version.ref = "androidx-room" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "androidx-room" }
 androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "androidx-viewpager2" }
 desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Sat May 31 22:24:36 CEST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- `HttpClient` has been improved to not depend on OkHttp APIs and to allow returning a raw unparsed http response.
- The parsing and database insertion of the schedule is now done inside suspending methods in `Dispatchers.IO` context.
- Room now requires the usage of suspending methods instead of blocking methods. It's now configured to use `Dispatchers.IO` as well, so thanks to the smart logic of Kotlin coroutines, there is no thread switching happening when parsing the XML response and inserting the rows in the database in a streaming fashion.
- The only behavior change compared to the old code is that parsing and database inserts are now performed on a thread from the `Dispatchers.IO` pool instead of a thread from OkHttp's thread pool.
- Also: replace direct calls to `SystemClock.elapsedRealtime()` with Kotlin's `TimeSource` abstraction. This makes the code more portable as `SystemClock` is an Android-only class.